### PR TITLE
Formatting bios on author pages

### DIFF
--- a/assets/scss/common/_hero.scss
+++ b/assets/scss/common/_hero.scss
@@ -6,6 +6,10 @@
   background-repeat: no-repeat;
   background-size: cover;
   color: $color-hero-text;
+  h1 {
+    margin-bottom:1.5rem;
+  }
+
   a {
     color: $color-hero-text;
     font-weight: bold;
@@ -40,6 +44,34 @@
   }
   &:nth-child(4n+3) {
     background-color: $color-hero2-background;
+  }
+
+  &--bio {
+    .contentblock {
+      text-align: center;
+      img {
+        text-align:center;
+        float:none;
+        margin-bottom:1.5rem;
+      }
+      p {
+        text-align:left;
+      }
+    }
+  }
+  @media (min-width: 769px) {
+    &--bio {
+      .contentblock {
+        min-height: 240px;
+        text-align:left;
+
+        img {
+          float: right;
+          margin-left: 1.5rem;
+          margin-bottom:0;
+        }
+      }
+    }
   }
 }
 

--- a/layouts/_default/author.html
+++ b/layouts/_default/author.html
@@ -8,13 +8,12 @@
 {{- end }}
 
 {{ define "mainwrapper" }}
-    <div class="hero"><div class="contentblock">
-        <h1>{{ .Params.fullname }}</h1>
-
-        <br/>
+    <div class="hero hero--bio"><div class="contentblock">
         {{- with .Params.images -}}
-            <img src="{{ (resources.Get (index . 0)).Permalink }}" alt="" />
+            <img class="avatar" src="{{ ((resources.Get (index . 0)).Fill "240x240 90% jpg").Permalink}}" alt="{{ $.Params.avatar_alt }}" />
         {{- end -}}
+
+        <h1>{{ .Params.fullname }}</h1>
 
         {{- .Content -}}
     </div></div>


### PR DESCRIPTION
This PR formats the bios on author pages. The images are resized for cachable URLs and better performance.

# Mobile view

![A screenshot of the top of the author page, showing the avatar image of the author above the bio.](https://user-images.githubusercontent.com/662664/112525892-a60c3100-8da1-11eb-8432-eb997ad413c5.png)

# Desktop view

![A screenshot of the top of the author page, showing the author image right of the bio.](https://user-images.githubusercontent.com/662664/112525927-b0c6c600-8da1-11eb-8e18-d0c74b13c927.png)
