### PR TITLE
Added recommendations to the end of the posts

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -49,6 +49,31 @@
     <div{{ if $.PublishDate }} itemprop="articleBody"{{ end }} class="body">
       {{ partial "content.html" . }}
     </div>
+    <div class="recommendations">
+      <h2>Did you like this post? Why not read more?</h2>
+      {{ $recommendationCount := 3 }}
+      <div class="grid grid--{{ $recommendationCount }}">
+        {{- $recommendations := first 0 (where $.Page.Site.RegularPages "Section" "blog") }}
+        {{- if isset .Params "recommendations" -}}
+          {{ range $key, $recommendation := .Params.recommendations -}}
+            {{- with $.Site.GetPage $recommendation -}}
+              {{- $recommendations = $recommendations | append . -}}
+            {{- end -}}
+          {{- end -}}
+        {{- end -}}
+
+        {{- $missingPosts := sub $recommendationCount (len $recommendations) }}
+        {{- range first $missingPosts (where $.Page.Site.RegularPages "Section" "blog") }}
+          {{- $recommendations = $recommendations | append . -}}
+        {{- end -}}
+
+        {{- range $recommendations -}}
+          <div class="grid__item">
+            {{ partial "postpreview" (dict "Link" .RelPermalink "Title" .Title "Image" (index .Params.images 0) "Content" .Content) }}
+          </div>
+        {{- end -}}
+      </div>
+    </div>
     {{ if (isset .Params "authors")}}
       <div class="bios">
       {{ range $key, $author := .Params.authors -}}


### PR DESCRIPTION
This PR adds recommendations to the end of the posts. It can be configured by adding the following metadata to blog posts:

```yaml
recommendations:
  - /blog/recommended-blog-post
```

It is important that there be no trailing slash (`/`) on the path. The engine will fill up the recommended posts with the latest posts from the front page to recommend 3 posts.

The recommendation looks like this:

![image](https://user-images.githubusercontent.com/662664/113166580-2ec41a80-9243-11eb-8988-99f2825e1630.png)
