### PR TITLE
Fixed permalinks and canonicals

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -71,4 +71,6 @@ imaging:
   resampleFilter: lanczos
   quality: 90
   anchor: smart
-
+permalinks:
+  /: /:filename/
+  blog: /blog/:year/:month/:day/:slug/

--- a/content/blog/2018-06-08-enabling-kms-encryption-running-amazon-rds-instance.md
+++ b/content/blog/2018-06-08-enabling-kms-encryption-running-amazon-rds-instance.md
@@ -7,6 +7,7 @@ authors:
   - renato_losio
 images:
   - blog/2018/04/safety-2890768_640.jpg
+slug: enabling-kms-encryption-running-amazon-rds-instance
 ---
 
 Since summer 2017, Amazon RDS supports [encryption](https://aws.amazon.com/about-aws/whats-new/2017/06/amazon-rds-enables-encryption-at-rest-for-additional-t2-instance-types/) at rest using AWS Key Management Service (KMS) for db.t2.small and db.t2.medium database instances, making the feature now available to virtually every instance class and type. 

--- a/content/blog/2018-06-12-character-sets-migrating-utf8mb4-pt_online_schema_change.md
+++ b/content/blog/2018-06-12-character-sets-migrating-utf8mb4-pt_online_schema_change.md
@@ -7,6 +7,7 @@ authors:
   - david_berube
 images:
   - blog/2018/04/problem.jpg
+slug: character-sets-migrating-utf8mb4-pt_online_schema_change
 ---
 
 Modern applications often feature the use of data in many different languages. This is often true even of applications that only offer a user facing interface in a single language. Many users may, for example, need to enter names which, although using Latin characters, feature diacritics; in other cases, they may need to enter text which contains Chinese or Japanese characters. Even if a user is capable of using an application localized for only one language, it may be necessary to deal with data from a wide variety of languages. 

--- a/content/blog/2018-06-18-tispark-data-insights-no-etl.md
+++ b/content/blog/2018-06-18-tispark-data-insights-no-etl.md
@@ -7,6 +7,7 @@ authors:
   - pingcap
 images:
   - blog/2018/06/tspark-query-path.png
+slug: tispark-data-insights-no-etl
 ---
 
 When we released [TiDB 2.0](http://bit.ly/tidb_2_0) in April, part of that announcement also included the release of [TiSpark](https://github.com/pingcap/tispark) 1.0--an integral part of the TiDB platform that makes complex analytics on “fresh” transactional data possible. Since then, many people in the TiDB community have been asking for more information about TiSpark. In this post, I will explain the motivation, inner workings, and future roadmap of this project.

--- a/content/blog/2018-06-28-nice-feature-in-mariadb-103-no-innodb-buffer-pool-in-coredumps.md
+++ b/content/blog/2018-06-28-nice-feature-in-mariadb-103-no-innodb-buffer-pool-in-coredumps.md
@@ -7,6 +7,7 @@ images:
   - blog/2018/06/InnoDB-buffer-pool-size.jpg
 authors:
   - jeff_gagne
+slug: nice-feature-in-mariadb-103-no-innodb-buffer-pool-in-coredumps
 ---
 
 MariaDB 10.3 is now generally available (10.3.7 was released GA on 2018-05-25). The article [What's New in MariaDB Server 10.3](https://mariadb.com/resources/blog/whats-new-mariadb-server-103) by the MariaDB Corporation lists three key improvements in 10.3: temporal data processing, Oracle compatibility features, and purpose-built storage engines. Even if I am excited about [MyRocks](https://mariadb.com/kb/en/library/myrocks/) and curious on [Spider](https://mariadb.com/kb/en/library/spider-storage-engine-overview/), I am also very interested in less flashy but still very important changes that make running the database in production easier. This post describes such improvement: **no** [**InnoDB Buffer Pool**](https://dev.mysql.com/doc/refman/5.7/en/innodb-buffer-pool.html) **in core dumps**. 

--- a/content/blog/2018-07-10-automate-minor-version-upgrades-mysql-rds.md
+++ b/content/blog/2018-07-10-automate-minor-version-upgrades-mysql-rds.md
@@ -7,6 +7,7 @@ images:
   - blog/2018/07/upgrade-minor-versions-MySQL-Amazon-RDS.jpg
 authors:
   - renato_losio
+slug: automate-minor-version-upgrades-mysql-rds
 ---
 
 Amazon RDS for MySQL offers the option to automate [minor version upgrades](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.MySQL.html#USER_UpgradeDBInstance.MySQL.Minor) using the _minor version upgrade policy_, a property that lets you decide if Amazon is allowed to perform the upgrades on your behalf. Usually the goal is not to upgrade automatically every RDS instance but to keep up to date automatically non-production deployments. This helps you address engine issues as soon as possible and improve the automation of the deployment process. 

--- a/content/blog/2018-08-02-easy-effective-building-external-dictionaries-clickhouse-pentaho-data-integration-tool.md
+++ b/content/blog/2018-08-02-easy-effective-building-external-dictionaries-clickhouse-pentaho-data-integration-tool.md
@@ -7,6 +7,7 @@ authors:
   - timur_solodovnikov
 images:
   - blog/2018/08/pentaho-clickhouse.jpg
+slug: easy-effective-building-external-dictionaries-clickhouse-pentaho-data-integration-tool
 ---
 
 In this post, I provide an illustration of how to use Pentaho Data Integration (PDI) tool to set up external dictionaries in MySQL to support ClickHouse. Although I use MySQL in this example, you can use any PDI supported source.

--- a/content/blog/2018-08-23-question-about-semi-synchronous-replication-answer-with-all-the-details.md
+++ b/content/blog/2018-08-23-question-about-semi-synchronous-replication-answer-with-all-the-details.md
@@ -7,6 +7,7 @@ authors:
   - jeff_gagne
 images: 
   - blog/2018/08/semi-sync-replication-MySQL.jpg
+slug: question-about-semi-synchronous-replication-answer-with-all-the-details
 ---
 
 I was recently asked a question by mail about [MySQL Lossless Semi-Synchronous Replication](https://dev.mysql.com/doc/refman/5.7/en/replication-semisync.html). As I think the answer could benefit many people, I am answering it in a blog post. The answer brings us to the internals of transaction committing, of semi-synchronous replication, of MySQL (server) crash recovery, and of storage engine (InnoDB) crash recovery. I am also debunking some misconceptions that I have often seen and heard repeated by many. Let's start by stating one of those misconceptions. 

--- a/content/blog/2018-08-29-7-checks-successfully-upgrade-mongodb-replica-set-production.md
+++ b/content/blog/2018-08-29-7-checks-successfully-upgrade-mongodb-replica-set-production.md
@@ -7,6 +7,7 @@ authors:
   - atish_a
 images:
   - blog/2018/08/checklist-for-the-upgrade-of-MongoDB-replica-set.jpg
+slug: 7-checks-successfully-upgrade-mongodb-replica-set-production
 ---
 
 MongoDB ships powerful features in each release. The new release brings new features while revisions add bug fixes, security patches or improvements to existing features. To bring most out these [releases](https://docs.mongodb.com/manual/release-notes/3.6/) to your plate you should always consider upgrading your MongoDB deployments. 

--- a/content/blog/2018-09-10-multi-master-with-mariadb-10-tutorial.md
+++ b/content/blog/2018-09-10-multi-master-with-mariadb-10-tutorial.md
@@ -7,6 +7,7 @@ authors:
   - aurelien_lequoy
 images:
   - blog/2018/09/pmacli-schema-diagram.jpg
+slug: multi-master-with-mariadb-10-tutorial
 ---
 
 The goal of this tutorial is to show you how to use multi-master to aggregate databases with the same name, but different data from different masters, on the same slave. 

--- a/content/blog/2018-09-24-minimize-mysql-deadlocks-3-steps.md
+++ b/content/blog/2018-09-24-minimize-mysql-deadlocks-3-steps.md
@@ -7,6 +7,7 @@ authors:
   - aftab_khan
 images:
   - blog/2018/09/application-deadlock-in-MySQL-transactions.jpg
+slug: minimize-mysql-deadlocks-3-steps
 ---
 
 MySQL has locking capabilities, for example table and row level locking, and such locks are needed to control data integrity in multi-user concurrency. Deadlocks—where two or more transactions are waiting for one another to give up locks before the transactions can proceed successfully—are an unwanted situation. It is a classic problem for all databases including MySQL/PostgreSQL/Oracle etc. By default, MySQL detects the deadlock condition and to break the deadlock it rolls back one of the transactions. 

--- a/content/blog/2018-10-03-percona-live-tutorial-elasticsearch-101.md
+++ b/content/blog/2018-10-03-percona-live-tutorial-elasticsearch-101.md
@@ -7,6 +7,7 @@ images:
   - blog/2018/10/MySQL-at-scale.jpg
 authors:
   - antonios_giannopoulos
+slug: percona-live-tutorial-elasticsearch-101
 ---
 
 ![Elasticsearch mark](blog/2018/10/elasticsearch-mark.png)

--- a/content/blog/2018-10-11-deploying-mysql-on-kubernetes-with-a-percona-based-operator.md
+++ b/content/blog/2018-10-11-deploying-mysql-on-kubernetes-with-a-percona-based-operator.md
@@ -7,6 +7,7 @@ images:
   - blog/2018/10/kubernetes-mysql-operator.png
 authors:
   - flavius_mecea
+slug: deploying-mysql-on-kubernetes-with-a-percona-based-operator
 ---
 
 In the context of providing managed WordPress hosting services, at [Presslabs](https://www.presslabs.com/) we operate with lots of small to medium-sized databases, in a DB-per-service model, as we call it. The workloads are mostly reads, so we need to efficiently scale that. The MySQL® asynchronous replication model fits the bill very well, allowing us to scale horizontally from one server—with the obvious availability pitfalls—to tens of nodes. The next release of the stack is going to be open-sourced. 

--- a/content/blog/2018-10-12-generating-identifiers-auto_increment-sequence.md
+++ b/content/blog/2018-10-12-generating-identifiers-auto_increment-sequence.md
@@ -7,6 +7,7 @@ authors:
   - alexey_mikotkin
 images:
   - blog/2018/09/generating-complex-sequences.png
+slug: generating-identifiers-auto_increment-sequence
 ---
 
 There are a number of options for generating ID values for your tables. In this post, Alexey Mikotkin of Devart explores your choices for generating identifiers with a look at auto_increment, triggers, UUID and sequences.

--- a/content/blog/2018-10-15-percona-live-europe-tutorial-query-optimization-workshop-tls-large-scale-session.md
+++ b/content/blog/2018-10-15-percona-live-europe-tutorial-query-optimization-workshop-tls-large-scale-session.md
@@ -7,6 +7,7 @@ images:
   - blog/2018/10/MySQL-at-scale.jpg
 authors:
   - jaime_crespo
+slug: percona-live-europe-tutorial-query-optimization-workshop-tls-large-scale-session
 ---
 
 [![MySQL has many ways to provide scalability, but can it provide it while at the same time guarantee perfect privacy? Learn it at my tutorial!](blog/2018/10/MySQL-at-scale.jpg)](https://www.percona.com/live/e18/sessions/tls-for-mysql-at-large-scale) For Percona Live Europe this year, [I got accepted](https://www.percona.com/live/e18/speaker/jaime-crespo) a workshop on query optimization and a 50-minute talk covering TLS for MySQL at Large Scale, talking about our experiences at the [Wikimedia Foundation](https://wikimediafoundation.org/).

--- a/content/blog/2018-10-16-export-to-json-from-mysql-all-ready-for-mongodb.md
+++ b/content/blog/2018-10-16-export-to-json-from-mysql-all-ready-for-mongodb.md
@@ -7,6 +7,7 @@ authors:
   - aftab_khan
 images:
   - blog/2018/10/export-data-to-JSON-from-MySQL.jpg
+slug: export-to-json-from-mysql-all-ready-for-mongodb
 ---
 
 This post walks through how to export data from [MySQL](https://dev.mysql.com/)® into JSON format, ready to ingest into [MongoDB](https://www.mongodb.com/)®. Starting from MySQL 5.7+, there is native support for JSON. MySQL provides functions that actually create JSON values, so I will be using these functions in this article to export to JSON from MySQL:

--- a/content/blog/2018-10-16-percona-live-europe-session-whats-new-mariadb-server-10-3.md
+++ b/content/blog/2018-10-16-percona-live-europe-session-whats-new-mariadb-server-10-3.md
@@ -7,6 +7,7 @@ images:
   - blog/2018/10/MariaDB-Foundation-vertical.png
 authors:
   - arjen_lentz
+slug: percona-live-europe-session-whats-new-mariadb-server-10-3
 ---
 
 **![MariaDB Foundation](blog/2018/10/MariaDB-Foundation-vertical.png)

--- a/content/blog/2018-10-17-percona-live-europe-presents-mariadb-system-versioned-tables.md
+++ b/content/blog/2018-10-17-percona-live-europe-presents-mariadb-system-versioned-tables.md
@@ -7,6 +7,7 @@ images:
   - blog/2018/10/PLE-Frankfurt-Logo.png
 authors:
   - federico_razzoli
+slug: percona-live-europe-presents-mariadb-system-versioned-tables
 ---
 
 ![PLE Frankfurt Logo](blog/2018/10/PLE-Frankfurt-Logo.png)

--- a/content/blog/2018-10-18-latest-mysql-replication-features.md
+++ b/content/blog/2018-10-18-latest-mysql-replication-features.md
@@ -7,6 +7,7 @@ images:
   - blog/2018/10/PLE-Frankfurt-Logo.png
 authors:
   - tiago_jorge
+slug: latest-mysql-replication-features
 ---
 
 ![PLE Frankfurt Logo](blog/2018/10/PLE-Frankfurt-Logo.png)

--- a/content/blog/2018-10-22-percona-live-europe-presents-need-speed-boosting-apache-cassandras-performance-using-netty.md
+++ b/content/blog/2018-10-22-percona-live-europe-presents-need-speed-boosting-apache-cassandras-performance-using-netty.md
@@ -7,6 +7,7 @@ images:
   - blog/2018/10/apache-cassandra-logo-3.png
 authors:
   - dinesh_joshi
+slug: percona-live-europe-presents-need-speed-boosting-apache-cassandras-performance-using-netty
 ---
 
 ![](blog/2018/10/apache-cassandra-logo-3.png)

--- a/content/blog/2018-10-23-mariadb-10-4-reverse-privileges-deny.md
+++ b/content/blog/2018-10-23-mariadb-10-4-reverse-privileges-deny.md
@@ -7,6 +7,7 @@ images:
   - blog/2018/10/MariaDB-Foundation-vertical.png
 authors:
   - vicențiu_ciorbaru
+slug: mariadb-10-4-reverse-privileges-deny
 ---
 
 ![MariaDB Foundation](blog/2018/10/MariaDB-Foundation-vertical.png)

--- a/content/blog/2018-10-26-percona-live-europe-presents-pg_chameleon-mysql-postgresql-replica-made-easy.md
+++ b/content/blog/2018-10-26-percona-live-europe-presents-pg_chameleon-mysql-postgresql-replica-made-easy.md
@@ -7,6 +7,7 @@ images:
   - blog/2018/10/igor_small.png
 authors:
   - federico_campoli
+slug: percona-live-europe-presents-pg_chameleon-mysql-postgresql-replica-made-easy
 ---
 
 ![](blog/2018/10/igor_small.png)

--- a/content/blog/2018-10-29-clickhouse-at-messagebird-analysing-billions-of-events-in-real-time.md
+++ b/content/blog/2018-10-29-clickhouse-at-messagebird-analysing-billions-of-events-in-real-time.md
@@ -8,6 +8,7 @@ images:
 authors:
   - felix_mattrat
   - aleksandar_aleksandrov
+slug: clickhouse-at-messagebird-analysing-billions-of-events-in-real-time
 ---
 
 [![MessageBird Logo](blog/2018/10/message-bird.png)](https://www.messagebird.com/en)

--- a/content/blog/2018-12-11-mysql-setup-hostinger-explained.md
+++ b/content/blog/2018-12-11-mysql-setup-hostinger-explained.md
@@ -7,6 +7,8 @@ authors:
   - donatas_abraitis
 images:
   - blog/2018/12/mysql-setup-hostinger.jpg
+slug: mysql-setup-hostinger-explained
+canonical: https://www.hostinger.com/blog/mysql-setup-at-hostinger-explained
 ---
 
 Ever wondered how hosting companies manage their MySQL database architecture? At [Hostinger,](https://www.hostinger.com/) we have various MySQL setups starting from the standalone replica-less instances to [Percona XtraDB Cluster](https://www.percona.com/software/mysql-database/percona-xtradb-cluster) (later just PXC), [ProxySQL](http://www.proxysql.com/) routing-based and even absolutely custom and unique solutions which I’m going to describe in this blog post. 

--- a/content/blog/2018-12-14-notes-mariadb-system-versioned-tables.md
+++ b/content/blog/2018-12-14-notes-mariadb-system-versioned-tables.md
@@ -7,6 +7,7 @@ authors:
   - federico_razzoli
 images:
   - blog/2018/12/mariadb-system-versioned-tables.jpg
+slug: notes-mariadb-system-versioned-tables
 ---
 
 As mentioned in a [previous post](https://www.percona.com/community-blog/2018/10/17/percona-live-europe-presents-mariadb-system-versioned-tables/), I gave a talk at [Percona Live Europe 2018](https://www.percona.com/live/e18/sessions/mariadb-system-versioned-tables) about system-versioned tables. This is a new MariaDB 10.3 feature, which consists of preserving old versions of a table rows. Each version has two timestamps that indicate the start (INSERT,UPDATE) of the validity of that version, and its end (DELETE, UPDATE). As a result, the user is able to query these tables as they appear at a point in the past, or how data evolved in a certain time range. An alternative name for this feature is _temporal table_, and I will use it in the rest of this text.

--- a/content/blog/2019-01-03-writing-killer-conference-proposal.md
+++ b/content/blog/2019-01-03-writing-killer-conference-proposal.md
@@ -7,6 +7,7 @@ images:
   - blog/2019/01/writing-a-killer-conference-proposal.jpg
 authors:
   - lorraine_pocklington
+site: writing-killer-conference-proposal
 ---
 
 ![writing a killer conference proposal](blog/2019/01/writing-a-killer-conference-proposal.jpg)

--- a/content/blog/2019-01-14-ilovefs-valentines-day.md
+++ b/content/blog/2019-01-14-ilovefs-valentines-day.md
@@ -7,6 +7,7 @@ authors:
   - lorraine_pocklington
 images:
   - blog/2019/02/ilovefs_postcard.jpg
+slug: ilovefs-valentines-day
 ---
 
 [**Free Software Foundation Europe**](https://fsfe.org/) (FSFE) is celebrating the creators of free software with their I Love Free Software campaign #ilovefs, a social campaign for Valentine’s Day. 

--- a/content/blog/2019-01-14-introduction-mongodb-replication.md
+++ b/content/blog/2019-01-14-introduction-mongodb-replication.md
@@ -7,6 +7,7 @@ authors:
   - danish_wadhwa
 images:
   - blog/2019/01/mongodb-replication.jpg
+slug: introduction-mongodb-replication
 ---
 
 MongoDB® is database software that stores data in the same format as [JSON](https://www.json.org/). The data structure of the database can be changed when required. The performance of the database is good and developers can easily use to it to connect their code to the database. 

--- a/content/blog/2019-03-15-london-open-source-database-community-meetup.md
+++ b/content/blog/2019-03-15-london-open-source-database-community-meetup.md
@@ -7,6 +7,7 @@ authors:
   - federico_razzoli
 images:
   - blog/2019/03/london-meetup.jpg
+slug: london-open-source-database-community-meetup
 ---
 
 I strongly believe in the community. 

--- a/content/blog/2019-04-18-percona-live-presents-vitess-running-sharded-mysql-kubernetes.md
+++ b/content/blog/2019-04-18-percona-live-presents-vitess-running-sharded-mysql-kubernetes.md
@@ -7,6 +7,7 @@ images:
   - blog/2019/04/sugu_sougoumarane.jpg
 authors:
   - sugu_sougoumarane
+slug: percona-live-presents-vitess-running-sharded-mysql-kubernetes
 ---
 
 The topic I'm presenting addresses a growing and unfulfilled need: the ability to run stateful workloads in Kubernetes. Running stateless applications is now considered a solved problem. However, it's currently not practical to put databases like MySQL in containers, give them to Kubernetes, and expect it to manage their life cycles. 

--- a/content/blog/2019-04-24-mysql-query-optimizer-explained-optimizer-trace.md
+++ b/content/blog/2019-04-24-mysql-query-optimizer-explained-optimizer-trace.md
@@ -7,6 +7,7 @@ images:
   - blog/2019/04/oysteing3.jpg
 authors:
   - oystein_grovlen
+slug: mysql-query-optimizer-explained-optimizer-trace
 ---
 
 During my presentation at [Percona Live 2019](https://www.percona.com/live/19/sessions/the-mysql-query-optimizer-explained-through-optimizer-trace) I will show how using Optimizer Trace can give insight into the inner workings of the MySQL Query Optimizer. Through the presentation, the audience will both be introduced to optimizer trace, learn more about the decisions the query optimizer makes, and learn about the query execution strategies the query optimizer has at its disposal. I'll be covering the main phases of the MySQL optimizer and its optimization strategies, including query transformations, data access strategies, the range optimizer, the join optimizer, and subquery optimization.

--- a/content/blog/2019-05-06-percona-live-presents-first-ever-tidb-track.md
+++ b/content/blog/2019-05-06-percona-live-presents-first-ever-tidb-track.md
@@ -7,6 +7,7 @@ images:
   - blog/2019/05/state-of-databases-2019.jpg
 authors:
   - pingcap
+slug: percona-live-presents-first-ever-tidb-track
 ---
 
 The PingCAP team has always been a strong supporter of Percona and the wider open source database community. As the people who work day in and day out on [TiDB](https://github.com/pingcap/tidb), an open source NewSQL database with MySQL compatibility, open source database is what gets us in the morning, and there’s no better place to share that passion than Percona Live. 

--- a/content/blog/2019-05-09-percona-live-presents-state-databases-2019.md
+++ b/content/blog/2019-05-09-percona-live-presents-state-databases-2019.md
@@ -7,6 +7,7 @@ images:
   - blog/2019/05/state-of-databases-2019.jpg
 authors:
   - dave_cohen
+slug: percona-live-presents-state-databases-2019
 ---
 
 ![state of databases 2019](blog/2019/05/state-of-databases-2019.jpg)

--- a/content/blog/2019-05-14-percona-live-presents-open-source-cloud-native-database.md
+++ b/content/blog/2019-05-14-percona-live-presents-open-source-cloud-native-database.md
@@ -7,6 +7,7 @@ images:
   - blog/2019/05/cloud-native-database.jpg
 authors:
   - dave_cohen
+slug: percona-live-presents-open-source-cloud-native-database
 ---
 
 ![an open source cloud native database](blog/2019/05/cloud-native-database.jpg)

--- a/content/blog/2019-05-17-percona-live-gonymizer-tool-anonymize-sensitive-postgresql-data-testing.md
+++ b/content/blog/2019-05-17-percona-live-gonymizer-tool-anonymize-sensitive-postgresql-data-testing.md
@@ -7,6 +7,7 @@ images:
   - blog/2019/05/gonymizer-postgres-data-anonymizer.jpg
 authors:
   - levi_junkert
+slug: percona-live-gonymizer-tool-anonymize-sensitive-postgresql-data-testing
 ---
 
 [SmithRX](https://smithrx.com/)[![gonymizer postgres data anonymizer](blog/2019/05/gonymizer-postgres-data-anonymizer.jpg)](https://smithrx.com/) is a next generation pharmacy benefit platform that is using the latest technology to radically reshape the prescription benefit management industry. To move quickly, we require the ability to iterate and test new versions of our software using production like data without violating Health Information Portability and Accountability Act (HIPAA) regulations. 

--- a/content/blog/2019-05-28-percona-live-presents-globalizing-player-accounts-mysql-riot-games.md
+++ b/content/blog/2019-05-28-percona-live-presents-globalizing-player-accounts-mysql-riot-games.md
@@ -7,6 +7,7 @@ images:
   - blog/2019/05/riot-games.jpg
 authors:
   - tyler_turk
+slug: percona-live-presents-globalizing-player-accounts-mysql-riot-games
 ---
 
 ![](blog/2019/05/riot-games.jpg)

--- a/content/blog/2019-07-08-tame-kubernetes-with-open-source-tools.md
+++ b/content/blog/2019-07-08-tame-kubernetes-with-open-source-tools.md
@@ -7,6 +7,7 @@ authors:
   - gaurav_belani
 images:
   - blog/2019/07/kubernetes-management-tools.jpg
+slug: tame-kubernetes-with-open-source-tools
 ---
 
 [Kubernetes](https://kubernetes.io/)’ popularity as the most-preferred open-source container-orchestration system has skyrocketed in the recent past. The [overall container market](https://enterprisersproject.com/article/2017/11/kubernetes-numbers-10-compelling-stats) is expected to cross USD 2.7 billion by 2020 with a CAGR of 40 percent. Three orchestrators spearhead this upward trend, namely Kubernetes, [Mesos](http://mesos.apache.org/), and [Docker Swarm](https://docs.docker.com/engine/swarm/). However, referring to the graph below, Kubernetes clearly leads the pack. 

--- a/content/blog/2019-07-16-concept-materialized-views-mongodb-sharded-clusters.md
+++ b/content/blog/2019-07-16-concept-materialized-views-mongodb-sharded-clusters.md
@@ -7,6 +7,7 @@ authors:
   - antonios_giannopoulos
 images:
   - blog/2019/07/MongoDB-materialized-views.jpg
+slug: concept-materialized-views-mongodb-sharded-clusters
 ---
 
 In one of my past [blogs](https://www.objectrocket.com/blog/mongodb/enhance-your-organization-security-with-mongodb-views/) I explained the contribution of MongoDB® views in organization security. In this blog, I will take it one step further and I will try to approach the concept of a materialized view in MongoDB. In computing, a materialized view is a database object that contains the results of a query (definition taken from Wikipedia). If you are already familiar with MongoDB views (or you read my [blog](https://www.objectrocket.com/blog/mongodb/enhance-your-organization-security-with-mongodb-views/)), you are now probably wondering why I am calling the MongoDB views materialized while it's well known that they are computed on the fly? Well, the answer is that in this blog, I am not going to discuss the built-in view capabilities of MongoDB – which by the way are not materialized –but for a technique on how to build, maintain and use a materialized views in a MongoDB sharded cluster.

--- a/content/blog/2019-07-23-impact-of-innodb_file_per_table-option-on-crash-recovery-time.md
+++ b/content/blog/2019-07-23-impact-of-innodb_file_per_table-option-on-crash-recovery-time.md
@@ -7,6 +7,7 @@ authors:
   - timur_solodovnikov
 images:
   - blog/2019/07/logo-mysql-170x115.png
+slug: impact-of-innodb_file_per_table-option-on-crash-recovery-time
 ---
 
 Starting at version MySQL5.6+ by default innodb_file_per_table is enabled and all data is stored in separate tablespaces. It provides some [advantages](https://dev.mysql.com/doc/refman/5.7/en/innodb-multiple-tablespaces.html). 

--- a/content/blog/2019-07-29-mysql-optimizer-naughty-aberrations-on-queries-combining-where-order-by-and-limit.md
+++ b/content/blog/2019-07-29-mysql-optimizer-naughty-aberrations-on-queries-combining-where-order-by-and-limit.md
@@ -7,6 +7,7 @@ images:
   - blog/2019/07/mysql-optimizer-choose-wrong-path.jpg
 authors:
   - jeff_gagne
+slug: mysql-optimizer-naughty-aberrations-on-queries-combining-where-order-by-and-limit
 ---
 
 Sometimes, the MySQL Optimizer chooses a wrong plan, and a query that should execute in less than 0.1 second ends-up running for 12 minutes! This is not a new problem: bugs about this can be traced back to 2014, and a blog post on this subject was published in 2015. But even if this is old news, because this problem recently came yet again to my attention, and because this is still not fixed in MySQL 5.7 and 8.0, this is a subject worth writing about.

--- a/content/blog/2019-08-01-how-to-build-a-percona-server-stack-on-a-raspberry-pi-3.md
+++ b/content/blog/2019-08-01-how-to-build-a-percona-server-stack-on-a-raspberry-pi-3.md
@@ -7,6 +7,7 @@ authors:
   - wayne
 images:
   - blog/2019/07/Percona-installation-on-Raspberry-Pi-3.jpg
+slug: how-to-build-a-percona-server-stack-on-a-raspberry-pi-3
 ---
 
 The blog post [_How to Compile Percona Server for MySQL 5.7 in Raspberry Pi 3_](https://www.percona.com/blog/2018/08/22/how-to-compile-percona-server-for-mysql-5-7-in-raspberry-pi-3/) by Walter Garcia, inspired me to create an updated install of Percona Server for the [Raspberry Pi 3+](https://www.raspberrypi.org/products/). 

--- a/content/blog/2019-08-07-mysql-how-we-got-from-30k-qps-to-101k-qps.md
+++ b/content/blog/2019-08-07-mysql-how-we-got-from-30k-qps-to-101k-qps.md
@@ -7,6 +7,7 @@ authors:
   - gurnish_anand
 images: 
   - blog/2019/08/tuning-mysql-for-throughput.jpg
+slug: mysql-how-we-got-from-30k-qps-to-101k-qps
 ---
 
 Late one evening, I was staring at one of our large MySQL installations and noticed the database was hovering around 7-10 run queue length (48 cores, \~500 gigs memory, fusionIO cards). I had been scratching my head on how to get more throughput from the database. This blog records the changes I made to tune performance in order to achieve a 300% better throughput in MySQL. I tested my theories on MySQL 5.6/Maria 10.1. While with 5.7 DBAs would turn to _performance_schema_ for the supporting metrics, I hope that you find the process interesting nevertheless.

--- a/content/blog/2019-08-14-minimalist-tooling-for-mysql-mariadb-dbas.md
+++ b/content/blog/2019-08-14-minimalist-tooling-for-mysql-mariadb-dbas.md
@@ -7,6 +7,7 @@ images:
   - blog/2019/08/dba-tools-minimalist-mysql-tooling.jpg
 authors:
   - geoff_winans
+slug: minimalist-tooling-for-mysql-mariadb-dbas
 ---
 
 In my roles as a DBA at various companies, I generally found the tooling to be quite lacking. Everything from metrics collection, alerting, backup management; they were either missing, incomplete or implemented poorly. [DBA-Tools](http://gitlab.com/gwinans/dba-tools) was born from a desire to build backup tools that supported my needs in smaller/non-cloud environments. As BASH is easily the most common shell available out there on systems running MySQL® or MariaDB®, it was an easy choice.

--- a/content/blog/2019-09-18-percona-live-europe-19-mongodb-4-2.md
+++ b/content/blog/2019-09-18-percona-live-europe-19-mongodb-4-2.md
@@ -7,6 +7,7 @@ images:
   - blog/2019/09/percona-live-europe2019.jpg
 authors:
   - antonios_giannopoulos
+slug: percona-live-europe-19-mongodb-4-2
 ---
 
 ![](blog/2019/09/percona-live-europe2019.jpg)

--- a/content/blog/2019-09-20-are-your-database-backups-good-enough.md
+++ b/content/blog/2019-09-20-are-your-database-backups-good-enough.md
@@ -7,6 +7,7 @@ authors:
   - jaime_crespo
 images:
   - blog/2019/08/this_is_fine.png
+slug: are-your-database-backups-good-enough
 ---
 
 In the last few years there have been several examples of major service problems affecting businesses data: outages causing data inconsistencies; unavailability or data loss, and [worldwide cyberattacks encrypting your files and asking for a ransom](https://en.wikipedia.org/wiki/WannaCry_ransomware_attack). 

--- a/content/blog/2019-09-25-percona-live-europe-presents-test-like-a-boss.md
+++ b/content/blog/2019-09-25-percona-live-europe-presents-test-like-a-boss.md
@@ -7,6 +7,7 @@ images:
   - blog/2019/09/dbdeployer.jpg
 authors:
   - giuseppe
+slug: percona-live-europe-presents-test-like-a-boss
 ---
 
 ![](blog/2019/09/dbdeployer.jpg)

--- a/content/blog/2019-12-13-percona-server-for-mysql-8-0-new-data-masking-feature.md
+++ b/content/blog/2019-12-13-percona-server-for-mysql-8-0-new-data-masking-feature.md
@@ -7,6 +7,7 @@ authors:
   - francisco_miguel
 images:
   - blog/2019/12/data-masking-Percona-Server-for-MySQL.jpg
+slug: percona-server-for-mysql-8-0-new-data-masking-feature
 ---
  
 

--- a/content/blog/2020-01-07-a-first-look-at-amazon-rds-proxy.md
+++ b/content/blog/2020-01-07-a-first-look-at-amazon-rds-proxy.md
@@ -7,6 +7,7 @@ authors:
   - renato_losio
 images:
   - blog/2019/12/allie-smith-zp-0uEqBwpU-unsplash-50.jpg
+slug: a-first-look-at-amazon-rds-proxy
 ---
 
 At [re:Invent](https://reinvent.awsevents.com/) in Las Vegas in December 2019, **AWS announced the public preview of [RDS Proxy](https://aws.amazon.com/rds/proxy/)**, a fully managed database proxy that sits between your application and RDS. The new service offers to "_share established database connections, improving database efficiency and application scalability"_. 

--- a/content/blog/2020-01-17-disk-of-yesteryear-compared-to-todays-ssd-drives.md
+++ b/content/blog/2020-01-17-disk-of-yesteryear-compared-to-todays-ssd-drives.md
@@ -7,6 +7,7 @@ authors:
   - wayne
 images:
   - blog/2020/01/enrico-sottocorna-HOhR-t0yZIU-unsplash.jpg
+slug: disk-of-yesteryear-compared-to-todays-ssd-drives
 ---
 
 ![](blog/2020/01/enrico-sottocorna-HOhR-t0yZIU-unsplash.jpg)

--- a/content/blog/2020-01-28-how-to-contribute-to-pmm-documentation.md
+++ b/content/blog/2020-01-28-how-to-contribute-to-pmm-documentation.md
@@ -7,6 +7,7 @@ authors:
   - daniil_bazhenov
 images:
   - blog/2020/01/PMM-Contribute-10.png
+slug: how-to-contribute-to-pmm-documentation
 ---
 
 We'd love to see more contributions towards the development and improvement of [Percona Monitoring and Management (PMM),](https://www.percona.com/software/database-tools/percona-monitoring-and-management) one of Percona's most valued projects. Like all of Percona's software, PMM is free and open-source. An area where we'd dearly love to see some community provided enhancement is in its documentation. In future blog posts, we'll provide some insight on how to contribute to our software but... the beauty of documentation is that it's straightforward to maintain, and you don't even have to be a programmer to be able to provide valuable corrections and enhancements. So it's a great place to start. In this post, we set out how you might be able to contribute to this to make PMM even better than it is already!

--- a/content/blog/2020-02-05-finding-mysql-scaling-problems-using-perf.md
+++ b/content/blog/2020-02-05-finding-mysql-scaling-problems-using-perf.md
@@ -7,6 +7,7 @@ authors:
   - daniel_black
 images:
   - blog/2020/01/ricardo-gomez-angel-87vUJY3ntyI-unsplash.jpg
+slug: finding-mysql-scaling-problems-using-perf
 ---
 
 

--- a/content/blog/2020-03-24-deploying-tarantool-cartridge-applications-with-zero-effort-part-1.md
+++ b/content/blog/2020-03-24-deploying-tarantool-cartridge-applications-with-zero-effort-part-1.md
@@ -7,6 +7,7 @@ images:
   - blog/2020/02/tarantool-new-instances-scaled.png
 authors:
   - elizaveta_dokshina
+slug: deploying-tarantool-cartridge-applications-with-zero-effort-part-1
 ---
 
 Tarantool is an open-source in-memory DB with a Lua application server on board. It's best used for apps that require high performance and horizontal scaling. Out of the box we support horizontal scaling via the [vshard](https://github.com/tarantool/vshard) module. There are quite a few things that you have to keep in mind when you work on your business logic, though. Not ideal. 

--- a/content/blog/2020-04-01-deploying-tarantool-cartridge-applications-with-zero-effort-part-2.md
+++ b/content/blog/2020-04-01-deploying-tarantool-cartridge-applications-with-zero-effort-part-2.md
@@ -7,6 +7,7 @@ images:
   - blog/2020/03/ycgmxxaqlvyslsrzoo6jnv1vmx0.jpeg
 authors:
   - elizaveta_dokshina
+slug: deploying-tarantool-cartridge-applications-with-zero-effort-part-2
 ---
 
 ![](blog/2020/03/ycgmxxaqlvyslsrzoo6jnv1vmx0.jpeg) 

--- a/content/blog/2020-04-07-our-offer-to-online-meetups-and-community-leaders.md
+++ b/content/blog/2020-04-07-our-offer-to-online-meetups-and-community-leaders.md
@@ -7,6 +7,7 @@ authors:
   - daniil_bazhenov
 images:
   - blog/2020/04/online-meetups-percona-linkedin.jpg
+slug: our-offer-to-online-meetups-and-community-leaders
 ---
 
 ![Offer of Percona Speakers for events](blog/2020/04/online-meetups-percona-linkedin.jpg)Percona’s Community team organizes our speakers at in-person events around the world, such as Percona Live, Percona University, and events sponsored by other organizations. However, like everyone else around the world, all our plans are on hold due to the Coronavirus pandemic. 

--- a/content/blog/2020-04-29-the-anatomy-of-luajit-tables-and-whats-special-about-them.md
+++ b/content/blog/2020-04-29-the-anatomy-of-luajit-tables-and-whats-special-about-them.md
@@ -7,6 +7,7 @@ authors:
   - yaroslav_dynnikov
 images:
   - blog/2020/04/xeyzb9g_fodczvifb-xym4-qdwa.png
+slug: the-anatomy-of-luajit-tables-and-whats-special-about-them
 ---
 
 I don't know about you, but I really like to get inside all sorts of systems. In this article, I’m going to tell you about the internals of Lua tables and special considerations for their use. Lua is my primary professional programming language, and if one wants to write good code, one needs at least to peek behind the curtain. If you are curious, follow me. 

--- a/content/blog/2020-05-03-how-to-contribute-dashboards-to-pmm.md
+++ b/content/blog/2020-05-03-how-to-contribute-dashboards-to-pmm.md
@@ -7,6 +7,7 @@ authors:
   - daniil_bazhenov
 images:
   - blog/2020/05/Contribute_to_dashboards_1.png
+slug: how-to-contribute-dashboards-to-pmm
 ---
 
 Have you already contributed to Percona’s open-source products or perhaps you wanted to try doing so? 

--- a/content/blog/2020-05-04-expert-mariadb-utilize-mariadb-server-effectively-percona-live-online-talk-preview.md
+++ b/content/blog/2020-05-04-expert-mariadb-utilize-mariadb-server-effectively-percona-live-online-talk-preview.md
@@ -7,6 +7,7 @@ authors:
   - colin_charles
 images:
   - blog/2020/05/Social-PL-Online-2020-1.jpg
+slug: expert-mariadb-utilize-mariadb-server-effectively-percona-live-online-talk-preview
 ---
 
 _[Percona Live Online](https://www.percona.com/live/conferences) Agenda Slot:  Tue 19 May • New York_ _11:00 p.m. • London 4:00 a.m. (Wed) • New Delhi 8:30 a.m. (Wed)_ _Level: Intermediate_

--- a/content/blog/2020-05-05-dynamic-tracing-for-finding-and-solving-mariadb-and-mysql-performance-problems-on-linux-percona-live-online-talk-preview.md
+++ b/content/blog/2020-05-05-dynamic-tracing-for-finding-and-solving-mariadb-and-mysql-performance-problems-on-linux-percona-live-online-talk-preview.md
@@ -7,6 +7,7 @@ authors:
   - valeriy_kravchuk
 images:
   - blog/2020/05/Social-PL-Online-2020-1.jpg
+slug: dynamic-tracing-for-finding-and-solving-mariadb-and-mysql-performance-problems-on-linux-percona-live-online-talk-preview
 ---
 
 _[Percona Live Online](https://www.percona.com/live/conferences) Agenda Slot (CORRECTED): Wed 20 May • New York 6:00 a.m. • London 11:00 a.m. • New Delhi 3:30 p.m._ _Level: Advanced_

--- a/content/blog/2020-05-06-orchestrating-cassandra-with-kubernetes-operator-and-yelp-paasta-percona-live-online-talk-preview.md
+++ b/content/blog/2020-05-06-orchestrating-cassandra-with-kubernetes-operator-and-yelp-paasta-percona-live-online-talk-preview.md
@@ -7,6 +7,7 @@ authors:
   - raghavendra_prabhu
 images:
   - blog/2020/05/Social-PL-Online-2020-1.jpg
+slug: orchestrating-cassandra-with-kubernetes-operator-and-yelp-paasta-percona-live-online-talk-preview
 ---
 
 _[Percona Live Online](https://www.percona.com/live/conferences) Agenda Slot: Tue 19 May • New York 3:00 p.m. • London 8:00 p.m. • New Delhi 12:30 a.m. (Wed)_ _Level: Intermediate_

--- a/content/blog/2020-05-07-mariadb-10-4-and-the-competition-percona-live-online-talk-preview.md
+++ b/content/blog/2020-05-07-mariadb-10-4-and-the-competition-percona-live-online-talk-preview.md
@@ -7,6 +7,7 @@ authors:
   - kaj_arno
 images:
   - blog/2020/05/Social-PL-Online-2020-1.jpg
+slug: mariadb-10-4-and-the-competition-percona-live-online-talk-preview
 ---
 
 [Percona Live Online](https://www.percona.com/live/conferences) Agenda Slot: Tue 19 May • New York 12:30 p.m. • London 5:30 p.m. • New Delhi 10:00 p.m.

--- a/content/blog/2020-05-09-kubernetes-the-swiss-army-knife-for-your-proxysql-deployments-percona-live-online-talk-preview.md
+++ b/content/blog/2020-05-09-kubernetes-the-swiss-army-knife-for-your-proxysql-deployments-percona-live-online-talk-preview.md
@@ -7,6 +7,7 @@ authors:
   - raghavendra_prabhu
 images:
   - blog/2020/05/Social-PL-Online-2020-1.jpg
+slug: kubernetes-the-swiss-army-knife-for-your-proxysql-deployments-percona-live-online-talk-preview
 ---
 
 _Percona Live Online Agenda Slot: Tue 19 May • New York 10:00 p.m. • London 3:00 a.m. (Wed) • New Delhi 7:30 a.m. (Wed)_

--- a/content/blog/2020-05-12-state-of-the-dolphin-percona-live-online-talk-preview.md
+++ b/content/blog/2020-05-12-state-of-the-dolphin-percona-live-online-talk-preview.md
@@ -7,6 +7,7 @@ authors:
   - lefred
 images:
   - blog/2020/05/Social-PL-Online-2020-1.jpg
+slug: state-of-the-dolphin-percona-live-online-talk-preview
 ---
 
 _[Percona Live Online](https://www.percona.com/live/conferences) Agenda Slot: Tue 19 May • New York 11:00 a.m. • London 4:00 p.m. • New Delhi 8:30 p.m._

--- a/content/blog/2020-05-13-anti-cheating-tool-for-massive-multiplayer-games-using-amazon-aurora-and-amazon-ml-services-percona-live-online-talk-preview.md
+++ b/content/blog/2020-05-13-anti-cheating-tool-for-massive-multiplayer-games-using-amazon-aurora-and-amazon-ml-services-percona-live-online-talk-preview.md
@@ -8,6 +8,7 @@ authors:
   - yahav_biran
 images:
   - blog/2020/05/Social-PL-Online-2020-1.jpg
+slug: anti-cheating-tool-for-massive-multiplayer-games-using-amazon-aurora-and-amazon-ml-services-percona-live-online-talk-preview
 ---
 
 _[Percona Live Online](https://www.percona.com/live/conferences) Agenda Slot: Tue 19 May • New York 4 p.m. • London 9 p.m. • New Delhi 1:30 a.m. (Wed)_ _Level:  Intermediate_

--- a/content/blog/2020-05-23-unexpected-slow-alter-table-mysql-5-7.md
+++ b/content/blog/2020-05-23-unexpected-slow-alter-table-mysql-5-7.md
@@ -8,6 +8,7 @@ authors:
   - alexandre_vaniachine
 images:
   - blog/2020/04/alter-table-different-on-larger-database.jpg
+slug: unexpected-slow-alter-table-mysql-5-7
 ---
 
 Usually one would expect that ALTER TABLE with ALGORITHM=COPY will be slower than the default ALGORITHM=INPLACE. In this blog post we describe the case when this is not so. 

--- a/content/blog/2020-05-29-join-proxysql-tech-talks-with-percona-on-june-4th-2020.md
+++ b/content/blog/2020-05-29-join-proxysql-tech-talks-with-percona-on-june-4th-2020.md
@@ -7,6 +7,7 @@ authors:
   - stacy
 images:
   - blog/2020/05/2160x1080-cover-Proxy-Percona-3.jpg
+slug: join-proxysql-tech-talks-with-percona-on-june-4th-2020
 ---
 
 Long months of the pandemic lockdown have brought to life many great online events enabling the MySQL community to get together and stay informed about the very recent developments and innovations available to MySQL users. It isn’t over yet! Next **Thursday, June 4th**, Percona & ProxySQL are co-hosting the [**ProxySQL Tech Talks with Percona**](https://bit.ly/2THdDqv) virtual meetup covering ProxySQL, MySQL and Percona XtraDB Cluster. 

--- a/content/blog/2020-06-01-percona-live-online-talk-enhancing-mysql-security-at-linkedin-by-karthik-appigatla.md
+++ b/content/blog/2020-06-01-percona-live-online-talk-enhancing-mysql-security-at-linkedin-by-karthik-appigatla.md
@@ -7,6 +7,7 @@ images:
   - blog/2020/06/SC-3-Matt-Percona.jpg
 authors:
   - mayank_sharma
+slug: percona-live-online-talk-enhancing-mysql-security-at-linkedin-by-karthik-appigatla
 ---
 
 MySQL, arguably the most popular relational database, is used pretty extensively at the popular professional social network LinkedIn. At Percona Live ONLINE 2020, the company’s flagship event held online for the first time due to the Covid-19 pandemic, Karthik Appigatla from LinkedIN’s database SRE team discussed the company’s approach to securing their database deployment without introducing operational hiccups or adversely affecting performance. 

--- a/content/blog/2020-06-02-percona-live-online-mysql-on-google-cloud-war-and-peace-by-akshay-suryawanshi-jeremy-cole.md
+++ b/content/blog/2020-06-02-percona-live-online-mysql-on-google-cloud-war-and-peace-by-akshay-suryawanshi-jeremy-cole.md
@@ -7,6 +7,7 @@ images:
   - blog/2020/06/SC-3-Matt-Percona.jpg
 authors:
   - cate_lawrence
+slug: percona-live-online-mysql-on-google-cloud-war-and-peace-by-akshay-suryawanshi-jeremy-cole
 ---
 
 This session at [Percona Live ONLINE](https://www.percona.com/live/conferences) was presented by Akshay Suryawanshi, Senior Production Engineer at Shopify, and Jeremy Cole, Senior Staff Production Engineer - Datastores at Shopify. Shopify is an online and on-premise commerce platform, founded in 2006. 

--- a/content/blog/2020-06-04-percona-projects-for-google-summer-of-code-2020.md
+++ b/content/blog/2020-06-04-percona-projects-for-google-summer-of-code-2020.md
@@ -7,6 +7,7 @@ authors:
   - puneet_kala
 images:
   - blog/2020/06/google-summer-of-code-2019-367x263-2.jpg
+slug: percona-projects-for-google-summer-of-code-2020
 ---
 
 ![GSC](blog/2020/06/google-summer-of-code-2019-367x263-1.jpg)We are proud to announce that Percona was selected as a participating organization for the [Google Summer of Code (GSoC) 2020 program](https://summerofcode.withgoogle.com/), this is our second year as a participating org with the GSoC program. 

--- a/content/blog/2020-06-11-percona-live-online-anti-cheating-tools-for-massive-multiplayer-games-using-amazon-aurora-and-amazon-ml-services.md
+++ b/content/blog/2020-06-11-percona-live-online-anti-cheating-tools-for-massive-multiplayer-games-using-amazon-aurora-and-amazon-ml-services.md
@@ -7,6 +7,7 @@ images:
   - blog/2020/06/image4.jpg
 authors:
   - cate_lawrence
+slug: percona-live-online-anti-cheating-tools-for-massive-multiplayer-games-using-amazon-aurora-and-amazon-ml-services
 ---
 
 Would you play a multiplayer game if you discovered other people are cheating? According to a survey by Irdeto, 60% of online games were negatively impacted by cheaters, and 77% of players said they would stop playing a multiplayer game if they think opponents are cheating. Player churn grows as cheating grows.

--- a/content/blog/2020-06-12-matt-yonkovit-its-a-crazy-world-and-these-trends-are-disrupting-and-breaking-your-database-infrastructure.md
+++ b/content/blog/2020-06-12-matt-yonkovit-its-a-crazy-world-and-these-trends-are-disrupting-and-breaking-your-database-infrastructure.md
@@ -7,6 +7,7 @@ authors:
   - cate_lawrence
 images:
   - blog/2020/06/PLO-Card-Matt.jpg
+slug: matt-yonkovit-its-a-crazy-world-and-these-trends-are-disrupting-and-breaking-your-database-infrastructure
 ---
 
 Matt Yonkovit, Chief Experience Officer at Percona, presented a session at this year's Percona Live ONLINE, sharing initial insights from the [Open Source Data Management Survey 2020.](https://www.percona.com/open-source-data-management-software-survey) The survey provides a critical insight first-hand into how enterprises of all sizes are using, developing, and troubleshooting open source database software. The full data will be released later this year with a detailed analysis.

--- a/content/blog/2020-06-15-percona-live-online-opening-keynote-state-of-open-source-databases-by-peter-zaitsev.md
+++ b/content/blog/2020-06-15-percona-live-online-opening-keynote-state-of-open-source-databases-by-peter-zaitsev.md
@@ -7,6 +7,7 @@ images:
   - blog/2020/06/SC-3-Matt-Percona.jpg
 authors:
   - cate_lawrence
+slug: percona-live-online-opening-keynote-state-of-open-source-databases-by-peter-zaitsev
 ---
 
 Peter Zaitsev is CEO and co-founder of Percona. He opened [Percona Live ONLINE](https://www.percona.com/live/conferences) with a keynote which took a look at the historical foundations of open source software and how they have shaped the field today.

--- a/content/blog/2020-06-19-making-a-tarantool-based-investment-business-core-for-alfa-bank.md
+++ b/content/blog/2020-06-19-making-a-tarantool-based-investment-business-core-for-alfa-bank.md
@@ -7,6 +7,7 @@ authors:
   - vladimir_drynkin
 images:
   - blog/2020/06/image3-1.jpg
+slug: making-a-tarantool-based-investment-business-core-for-alfa-bank
 ---
 
 ![A still from "Our Secret Universe: The Hidden Life of the Cell"](blog/2020/06/image3-1.jpg) 

--- a/content/blog/2020-06-23-percona-live-online-talk-optimize-and-troubleshoot-mysql-using-percona-monitoring-and-management-by-peter-zaitsev.md
+++ b/content/blog/2020-06-23-percona-live-online-talk-optimize-and-troubleshoot-mysql-using-percona-monitoring-and-management-by-peter-zaitsev.md
@@ -7,6 +7,7 @@ images:
   - blog/2020/06/SC-3-Matt-Percona.jpg
 authors:
   - mayank_sharma
+slug: percona-live-online-talk-optimize-and-troubleshoot-mysql-using-percona-monitoring-and-management-by-peter-zaitsev
 ---
 
 Incorporating a database in an organization is a complicated task that involves a lot of people besides the DBAs. This is something that Peter Zaitsev, co-founder and CEO of Percona, understands very well. 

--- a/content/blog/2020-06-24-cassandra-where-and-how-by-john-schulz.md
+++ b/content/blog/2020-06-24-cassandra-where-and-how-by-john-schulz.md
@@ -7,6 +7,7 @@ authors:
   - mayank_sharma
 images:
   - blog/2020/06/PLO-Card-Cassandra.jpg
+slug: cassandra-where-and-how-by-john-schulz
 ---
 
 If Percona Live ONLINE had graded its talks by skill level this year, John Schulz’s talk would have been essential viewing in the Beginners track. (You can watch all the event’s presentations now on [Percona’s YouTube channel.](https://www.youtube.com/user/PerconaMySQL/videos)) This talk was a good overview and meant for anyone who had heard of the Apache Cassandra distributed database but wasn’t sure whether it would be suitable for their project or not. 

--- a/content/blog/2020-06-26-mariadb-server-fest-call-for-papers.md
+++ b/content/blog/2020-06-26-mariadb-server-fest-call-for-papers.md
@@ -7,6 +7,7 @@ authors:
   - kaj_arno
 images:
   - blog/2020/06/MDBS_Fest_logowhite_bg.png
+slug: mariadb-server-fest-call-for-papers
 ---
 
 In the week of 14-20 September 2020, MariaDB Foundation will host the MariaDB Server Fest Online Conference. We welcome the Percona Community not just to participate, but also to submit papers for the event. We already have Peter Zaitsev joining as keynoter; we hope for more to come. 

--- a/content/blog/2020-07-24-iiot-platform-databases-how-mail-ru-cloud-solutions-deals-with-petabytes-of-data-coming-from-a-multitude-of-devices.md
+++ b/content/blog/2020-07-24-iiot-platform-databases-how-mail-ru-cloud-solutions-deals-with-petabytes-of-data-coming-from-a-multitude-of-devices.md
@@ -7,6 +7,7 @@ images:
   - blog/2020/07/image6.png
 authors:
   - andrey_sergeev
+slug: iiot-platform-databases-how-mail-ru-cloud-solutions-deals-with-petabytes-of-data-coming-from-a-multitude-of-devices
 ---
 
 ![IIoT platform databases - How Mail.ru Cloud Solutions](blog/2020/07/image6.png) Hello, my name is Andrey Sergeyev and I work as a Head of IoT Solution Development at [Mail.ru Cloud Solutions](https://mcs.mail.ru/). We all know there is no such thing as a universal database. Especially when the task is to build an IoT platform that would be capable of processing millions of events from various sensors in near real-time. 

--- a/content/blog/2020-09-03-iot-performance-bottlenecks-and-open-source-databases.md
+++ b/content/blog/2020-09-03-iot-performance-bottlenecks-and-open-source-databases.md
@@ -7,6 +7,7 @@ images:
   - blog/2020/08/iot1-scaled.jpg
 authors:
   - gaurav_belani
+slug: iot-performance-bottlenecks-and-open-source-databases
 ---
 
 The Internet of Things (IoT), in essence, is all about everyday devices that are readable, recognizable, trackable, and/or controllable via the Internet, regardless of the communication means — RFID, wireless LAN, and so on. The total installed base of IoT connected devices is projected to amount to [21.5 billion units worldwide by 2025](https://www.statista.com/statistics/1101442/iot-number-of-connected-devices-worldwide/). Thanks to IoT, the proliferation of data can be quite daunting. Hence, businesses should effectively organize and work with this enormous amount of valuable data. 

--- a/content/blog/2020-09-04-two-weeks-to-mariadb-server-fest.md
+++ b/content/blog/2020-09-04-two-weeks-to-mariadb-server-fest.md
@@ -7,6 +7,7 @@ images:
   - blog/2020/09/mariadb_fest_video.jpeg
 authors:
   - kaj_arno
+slug: two-weeks-to-mariadb-server-fest
 ---
 
 There is still time to [register](https://mariadb.org/fest-registration/) for the MariaDB Server Fest 2020!

--- a/content/blog/2020-09-07-google-summer-of-code-refactor-pmm-framework-project-with-percona.md
+++ b/content/blog/2020-09-07-google-summer-of-code-refactor-pmm-framework-project-with-percona.md
@@ -7,6 +7,7 @@ authors:
   - meet_patel
 images:
   - blog/2020/09/Screenshot-2020-09-07-at-14.46.59.png
+slug: google-summer-of-code-refactor-pmm-framework-project-with-percona
 ---
 
 I am **Meet Patel**, 2nd year undergraduate at DAIICT, Gandhinagar, India; pursuing a bachelor’s degree in Information and Communication Technology with a minor in Computational Science. 

--- a/content/blog/2020-09-28-how-to-write-your-index-in-tarantool.md
+++ b/content/blog/2020-09-28-how-to-write-your-index-in-tarantool.md
@@ -7,6 +7,7 @@ images:
   - blog/2020/09/tarantool_cover.png
 authors:
   - oleg_babin
+slug: how-to-write-your-index-in-tarantool
 ---
 
 Tarantool is an application server and a database. The server part is written in C, and the user is provided with a Lua interface to use it. Then, [Tarantool](https://www.tarantool.io/en/developers/) is an open-source product with its source code in open access, and anyone can develop and distribute Tarantool-based software freely. 

--- a/content/blog/2020-10-01-database-schema-management-via-liquibase.md
+++ b/content/blog/2020-10-01-database-schema-management-via-liquibase.md
@@ -7,6 +7,7 @@ authors:
   - ronak_rahman
 images:
   - blog/2020/10/Liquibase.jpg
+slug: database-schema-management-via-liquibase
 ---
 
 Creating the database for an application is simple and easy. However, database script management gets complicated in a hurry when you need to support multiple versions, work with multiple teams, and apply the same changes to multiple types of databases.  

--- a/content/blog/2020-10-01-mariadb-10-5-new-features-for-troubleshooting-percona-live-online-talk-preview.md
+++ b/content/blog/2020-10-01-mariadb-10-5-new-features-for-troubleshooting-percona-live-online-talk-preview.md
@@ -7,6 +7,7 @@ authors:
   - valeriy_kravchuk
 images:
   - blog/2020/10/DB-PLO-Blog-Image-2020-10-05.jpg
+slug: mariadb-10-5-new-features-for-troubleshooting-percona-live-online-talk-preview
 ---
 
 _[Percona Live Online](https://www.percona.com/live/agenda) Agenda Slot: Wed 21 Aug • New York 12:00 midnight • London 05:00 a.m. • New Delhi 9:30 a.m. • Singapore 12:00 noon_

--- a/content/blog/2020-10-02-kunlun-distributed-db-cluster-intro-percona-live-online-talk-preview.md
+++ b/content/blog/2020-10-02-kunlun-distributed-db-cluster-intro-percona-live-online-talk-preview.md
@@ -7,6 +7,7 @@ authors:
   - david_zhao
 images:
   - blog/2020/10/DB-PLO-Blog-Image-2020-10-05.jpg
+slug: kunlun-distributed-db-cluster-intro-percona-live-online-talk-preview
 ---
 
 _[Percona Live Online](https://www.percona.com/live/agenda) Agenda Slot: Tue 20 Oct • New York 9:30 p.m. • London 02:30 a.m. (next day) • New Delhi 7:00 a.m. • Singapore 09:30 a.m._

--- a/content/blog/2020-10-06-nosql-endgame-percona-live-online-talk-preview.md
+++ b/content/blog/2020-10-06-nosql-endgame-percona-live-online-talk-preview.md
@@ -8,6 +8,7 @@ authors:
   - werner_keil
 images:
   - blog/2020/10/DB-PLO-Blog-Image-2020-10-05.jpg
+slug: nosql-endgame-percona-live-online-talk-preview
 ---
 
 _[Percona Live Online Agenda](https://www.percona.com/live/agenda) Slot: Tue 20 Oct • New York 3:00 p.m. • London 8:00 p.m. • New Delhi 12:30 a.m. (next day) • Singapore 3:00 a.m._

--- a/content/blog/2020-10-08-mysql-ecosystem-on-arm-percona-live-online-talk-preview.md
+++ b/content/blog/2020-10-08-mysql-ecosystem-on-arm-percona-live-online-talk-preview.md
@@ -7,6 +7,7 @@ authors:
   - krunal_bauskar
 images:
   - blog/2020/10/DB-PLO-Blog-Image-2020-10-05.jpg
+slug: mysql-ecosystem-on-arm-percona-live-online-talk-preview
 ---
 
 _[Percona Live Online Agenda](https://www.percona.com/live/agenda) Slot: Tue 20 Oct • New York 8:00 p.m. • London 1:00 a.m (next day) • New Delhi 5:30 a.m. • Singapore 8:00 a.m._

--- a/content/blog/2020-10-08-serverless-databases-the-good-the-bad-and-the-ugly-percona-live-online-talk-preview.md
+++ b/content/blog/2020-10-08-serverless-databases-the-good-the-bad-and-the-ugly-percona-live-online-talk-preview.md
@@ -7,6 +7,7 @@ authors:
   - renato_losio
 images:
   - blog/2020/10/DB-PLO-Blog-Image-2020-10-05.jpg
+slug: serverless-databases-the-good-the-bad-and-the-ugly-percona-live-online-talk-preview
 ---
 
 _[Percona Live Online Agenda](https://www.percona.com/live/agenda) Slot: Wed 21 Oct • New York 4:30 a.m. • London 9:30 a.m • New Delhi 2:00 p.m. • Singapore 4:30 p.m._

--- a/content/blog/2020-10-09-analytical-queries-in-mysql-percona-live-online-talk-preview.md
+++ b/content/blog/2020-10-09-analytical-queries-in-mysql-percona-live-online-talk-preview.md
@@ -7,6 +7,7 @@ authors:
   - oystein_grovlen
 images:
   - blog/2020/10/DB-PLO-Blog-Image-2020-10-05.jpg
+slug: analytical-queries-in-mysql-percona-live-online-talk-preview
 ---
 
 _[Percona Live Online Agenda](https://www.percona.com/live/agenda) Slot: Tue 20 Oct • New York 6:00 p.m. • London 11:00 p.m. • New Delhi 3:30 a.m. • Singapore 6:00 a.m._

--- a/content/blog/2020-10-10-vitess-online-schema-migration-automation-percona-live-online-talk-preview.md
+++ b/content/blog/2020-10-10-vitess-online-schema-migration-automation-percona-live-online-talk-preview.md
@@ -7,6 +7,7 @@ images:
   - blog/2020/10/DB-PLO-Blog-Image-2020-10-05.jpg
 authors:
   - shlomi_noach
+slug: vitess-online-schema-migration-automation-percona-live-online-talk-preview
 ---
 
 _[Percona Live Online Agenda](https://www.percona.com/live/agenda) Slot: Wed 21 Oct • New York 2:30 a.m. • London 7:30 a.m. • New Delhi 12:00 noon • Singapore 2:30 p.m._

--- a/content/blog/2020-10-12-what-if-we-could-use-machine-learning-models-as-tables-percona-live-online-talk-preview.md
+++ b/content/blog/2020-10-12-what-if-we-could-use-machine-learning-models-as-tables-percona-live-online-talk-preview.md
@@ -7,6 +7,7 @@ authors:
   - jorge_torres
 images:
   - blog/2020/10/DB-PLO-Blog-Image-2020-10-05.jpg
+slug: what-if-we-could-use-machine-learning-models-as-tables-percona-live-online-talk-preview
 ---
 
 _[Percona Live Online Agenda](https://www.percona.com/live/agenda) Slot: Tue 20 Oct • New York 1:30 p.m. • London 6:30 p.m. • New Delhi 11:00 p.m. • Singapore 1:30 a.m. (next day)_

--- a/content/blog/2020-10-13-sharding-diy-or-out-of-the-box-solution-percona-live-online-talk-preview.md
+++ b/content/blog/2020-10-13-sharding-diy-or-out-of-the-box-solution-percona-live-online-talk-preview.md
@@ -7,6 +7,7 @@ authors:
   - art_vanscheppingen
 images:
   - blog/2020/10/DB-PLO-Blog-Image-2020-10-05.jpg
+slug: sharding-diy-or-out-of-the-box-solution-percona-live-online-talk-preview
 ---
 
 _[Percona Live Online Agenda](https://www.percona.com/live/agenda) Slot: Wed 21 Oct • New York 7:00 a.m. • London 12:00 noon • New Delhi 4:30 p.m. • Singapore 7:00 p.m._

--- a/content/blog/2020-10-14-dbdeployer-the-community-edition-percona-live-online-talk-preview.md
+++ b/content/blog/2020-10-14-dbdeployer-the-community-edition-percona-live-online-talk-preview.md
@@ -7,6 +7,7 @@ authors:
   - giuseppe
 images:
   - blog/2020/10/DB-PLO-Blog-Image-2020-10-05.jpg
+slug: dbdeployer-the-community-edition-percona-live-online-talk-preview
 ---
 
 _[Percona Live Online Agenda](https://www.percona.com/live/agenda) Slot: Wed 21 Oct • New York 3:30 a.m. • London 8:30 a.m. • New Delhi 1:00 p.m. • Singapore 3:30 p.m._

--- a/content/blog/2020-10-16-engineering-data-reliably-using-slo-theory-percona-live-online-talk-preview.md
+++ b/content/blog/2020-10-16-engineering-data-reliably-using-slo-theory-percona-live-online-talk-preview.md
@@ -7,6 +7,7 @@ images:
   - blog/2020/10/DB-PLO-Blog-Image-2020-10-05.jpg
 authors:
   - emily_gorcenski
+slug: engineering-data-reliably-using-slo-theory-percona-live-online-talk-preview
 ---
 
 _[Percona Live Online Agenda](https://www.percona.com/live/agenda) Slot: Tue 20 Oct • New York 12:30 p.m. • London 5:30 p.m. • New Delhi 10:00 p.m. • Singapore 12:30 a.m. (next day)_

--- a/content/blog/2020-10-16-the-state-of-proxysql-2020-edition-percona-live-online-talk-preview.md
+++ b/content/blog/2020-10-16-the-state-of-proxysql-2020-edition-percona-live-online-talk-preview.md
@@ -7,6 +7,7 @@ authors:
   - rene_cannao
 images:
   - blog/2020/10/DB-PLO-Blog-Image-2020-10-05.jpg
+slug: the-state-of-proxysql-2020-edition-percona-live-online-talk-preview
 ---
 
 _[Percona Live Online Agenda](https://www.percona.com/live/agenda) Slot: Wed 21 Oct • New York 7:30 a.m. • London 12:30 p.m. • New Delhi 5:00 p.m. • Singapore 7:30 p.m._

--- a/content/blog/2020-10-19-mysql-8-0-document-store-discovery-of-a-new-world-percona-live-online-talk-preview.md
+++ b/content/blog/2020-10-19-mysql-8-0-document-store-discovery-of-a-new-world-percona-live-online-talk-preview.md
@@ -7,6 +7,7 @@ authors:
   - lefred
 images:
   - blog/2020/10/DB-PLO-Blog-Image-2020-10-05.jpg
+slug: mysql-8-0-document-store-discovery-of-a-new-world-percona-live-online-talk-preview
 ---
 
 _[Percona Live Online Agenda](https://www.percona.com/live/agenda) Slot: Wed 21 Oct • New York 5:00 a.m. • London 10:00 a.m. • New Delhi 2:30 p.m. • Singapore 5:00 p.m._

--- a/content/blog/2020-10-23-mayastor-lightning-fast-storage-for-kubernetes.md
+++ b/content/blog/2020-10-23-mayastor-lightning-fast-storage-for-kubernetes.md
@@ -7,6 +7,7 @@ authors:
   - brian_matheson
 images:
   - blog/2020/10/image1.png
+slug: mayastor-lightning-fast-storage-for-kubernetes
 ---
 
 At MayaData we like new tech. Tech that makes our databases perform better. Tech like [lockless ring buffers](https://www.kernel.org/doc/Documentation/trace/ring-buffer-design.txt), [NVMe-oF](https://en.wikipedia.org/wiki/NVM_Express), and [Kubernetes](https://kubernetes.io/). In this blog post we’re going to see those technologies at work to give us awesome block storage performance with flexibility and simple operations.

--- a/content/blog/2020-10-26-zero-downtime-schema-change-with-liquibase-percona.md
+++ b/content/blog/2020-10-26-zero-downtime-schema-change-with-liquibase-percona.md
@@ -7,6 +7,7 @@ authors:
   - ronak_rahman
 images:
   - blog/2020/10/image1-1.png
+slug: zero-downtime-schema-change-with-liquibase-percona
 ---
 
 I am always surprised to learn something new whenever I talk to a member of the open-source community. No matter how much I think I have heard of every use case there is for [Liquibase](https://www.liquibase.org) (and database change management in general), I always hear something that makes this space still feel new. There’s always something left to discover. 

--- a/content/blog/2020-10-30-how-to-build-a-high-performance-application-on-tarantool-from-scratch.md
+++ b/content/blog/2020-10-30-how-to-build-a-high-performance-application-on-tarantool-from-scratch.md
@@ -7,6 +7,7 @@ authors:
   - mons_anderson
 images:
   - blog/2020/10/image5.png
+slug: how-to-build-a-high-performance-application-on-tarantool-from-scratch
 ---
 
 ![tarantool start](blog/2020/10/image1.jpg) 

--- a/content/blog/2020-11-23-on-the-observability-of-outliers.md
+++ b/content/blog/2020-11-23-on-the-observability-of-outliers.md
@@ -7,6 +7,7 @@ authors:
   - koehntopp
 images:
   - blog/2020/11/obs-no.png
+slug: on-the-observability-of-outliers
 ---
 
 At work, I am in an ongoing discussion with a number of people on the Observability of Outliers. It started with the age-old question “How do I find slow queries in my application?” aka “What would I want from tooling to get that data and where should that tooling sit?”

--- a/content/blog/2020-12-01-not-joining-on-performance_schema.md
+++ b/content/blog/2020-12-01-not-joining-on-performance_schema.md
@@ -7,6 +7,8 @@ authors:
   - koehntopp
 images:
   - blog/2020/12/Screenshot-2020-12-01-at-23.21.51.png
+slug: not-joining-on-performance_schema
+canonical: https://blog.koehntopp.info/2020/12/01/not-joining-on-performance-schema.html
 ---
 
 The tables in `PERFORMANCE_SCHEMA` (`P_S`) are not actually tables. You should not think of them as tables, even if your SQL works on them. You should not JOIN them, and you should not GROUP or ORDER BY them.

--- a/content/blog/2020-12-04-fixing-common-postgresql-performance-bottlenecks.md
+++ b/content/blog/2020-12-04-fixing-common-postgresql-performance-bottlenecks.md
@@ -7,6 +7,7 @@ authors:
   - michael_aboagye
 images:
   - blog/2020/08/social-forums-postgresql-general-discussion.jpg
+slug: fixing-common-postgresql-performance-bottlenecks
 ---
 
 Overview

--- a/content/blog/2020-12-10-embracing-the-stream.md
+++ b/content/blog/2020-12-10-embracing-the-stream.md
@@ -7,6 +7,8 @@ authors:
   - koehntopp
 images:
   - blog/2020/12/stream-migrate-now.png
+slug: embracing-the-stream
+canonical: https://blog.koehntopp.info/2020/12/09/embracing-the-stream.html
 ---
 
 So this happened: [CentOS Project shifts focus to CentOS Stream](https://lists.centos.org/pipermail/centos-announce/2020-December/048208.html)

--- a/content/blog/2021-01-04-fork-exec-wait-and-exit.md
+++ b/content/blog/2021-01-04-fork-exec-wait-and-exit.md
@@ -6,6 +6,8 @@ images:
   - blog/2021/01/prozesswechsel.png
 authors:
   - koehntopp
+slug: fork-exec-wait-and-exit
+canonical: https://isotopp.github.io/2007/01/07/fork-exec-wait-und-exit.html
 ---
 
 

--- a/content/blog/2021-02-24-how-to-speed-up-re-sync-of-dropped-percona-xtradb-cluster-node.md
+++ b/content/blog/2021-02-24-how-to-speed-up-re-sync-of-dropped-percona-xtradb-cluster-node.md
@@ -5,6 +5,7 @@ authors:
   - wayne
 images:
   - blog/2021/02/Blog-Community-Pic.jpg
+slug: how-to-speed-up-re-sync-of-dropped-percona-xtradb-cluster-node
 ---
 
 ## The Problem


### PR DESCRIPTION
This change fixes the blog post permalinks to be similar to the current Percona community blog structure (`https://percona.community/blog/YYYY/MM/DD/post-slug-here`). This will make it easier to add redirects for the existing posts. It also adds canonical meta tags where appropriate.

Signed-off-by: Janos Pasztor <janos@pasztor.at>