### PR TITLE
Mobile view for post page bios

### DIFF
--- a/assets/scss/bio.scss
+++ b/assets/scss/bio.scss
@@ -28,4 +28,29 @@
   &__content {
     flex:1;
   }
+
+  @media screen and (max-width: 768px) {
+    &__bio {
+      display: block;
+      position:relative;
+    }
+    &__content {
+      flex:none;
+    }
+    h2 {
+      height: 10.5rem;
+      display: flex;
+      padding-right:12rem;
+      flex-direction: column;
+      justify-content: center;
+      span {
+        display: block;
+      }
+    }
+    img {
+      position:absolute;
+      top: 1.5rem;
+      right: 0;
+    }
+  }
 }

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -80,7 +80,7 @@
         <div class="bios__bio">
           {{- with $.Site.GetPage (print "/authors/" $author) -}}
             <div class="bios__content">
-              <h2>{{ .Params.fullname }}</h2>
+              <h2><span>{{ .Params.fullname }}</span></h2>
               {{ .Content }}
               <p><a href="/authors/{{ $author }}">See all posts by {{ .Params.fullname }} &raquo;</a></p>
             </div>


### PR DESCRIPTION
This change adds a mobile view for author bios on post pages.

![image](https://user-images.githubusercontent.com/662664/113179654-258d7a80-9250-11eb-83a5-873bacda89cc.png)

Signed-off-by: Janos Pasztor <janos@pasztor.at>