### PR TITLE
Adding 'Edit this on GitHub' link to all pages

### DIFF
--- a/assets/scss/common/_common.scss
+++ b/assets/scss/common/_common.scss
@@ -7,3 +7,4 @@
 @import "hero";
 @import "typography";
 @import "pagination";
+@import "edit";

--- a/assets/scss/common/_edit.scss
+++ b/assets/scss/common/_edit.scss
@@ -1,0 +1,25 @@
+@import "base";
+@import "variables";
+
+.edit-on-github {
+  font-size:0.8rem;
+  text-align:right;
+  .container {
+    @include container;
+  }
+  a {
+    background-color: $color-footer-top;
+    color: $color-background-footer-light;
+    text-decoration:none;
+    display:inline-block;
+    border-top-left-radius: 0.5rem;
+    border-top-right-radius:0.5rem;
+    padding-left:0.5rem;
+    padding-right:0.5rem;
+    transition: 0.2s background-color ease-in-out;
+    &:hover {
+      color: $color-background-footer-light;
+      background-color:$color-hero-background;
+    }
+  }
+}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -85,6 +85,14 @@
       {{ end }}
     </main>
 
+    {{ block "edit" . }}
+      <div class="edit-on-github">
+        <div class="container">
+          <a href="https://github.com/percona/community/edit/main/content/{{ .File }}" target="_blank" rel="noreferrer noopener">✎ Edit this page on GitHub</a>
+        </div>
+      </div>
+    {{ end }}
+
     <footer class="page">
       <h1 class="aria-only" id="footer-heading" aria-hidden="false">Footer</h1>
       <div class="page-footer">


### PR DESCRIPTION
This PR adds an 'Edit this on GitHub' link to all pages.

Desktop view:

![image](https://user-images.githubusercontent.com/662664/113838988-945a5e80-978f-11eb-9ea7-c960c1009de4.png)

Mobile view:

![image](https://user-images.githubusercontent.com/662664/113839065-a5a36b00-978f-11eb-94bb-fb50dc1f6792.png)
