### PR TITLE
Update 2024-02-19-percona-monthly-bug-report-january-2024.md

### DIFF
--- a/content/blog/2024/2024-02-19-percona-monthly-bug-report-january-2024.md
+++ b/content/blog/2024/2024-02-19-percona-monthly-bug-report-january-2024.md
@@ -1,5 +1,5 @@
 ---
-title: "Percona Monthly Bug Report: January 2024"
+title: "Percona Bug Report: January 2024"
 date: "2024-02-19T00:00:00+00:00"
 tags: ['Percona', 'opensource', 'PMM', 'Kubernetes', 'MySQL']
 authors:


### PR DESCRIPTION
Removed Monthly keyword, since it is not a monthly bug news letter.