### PR TITLE
Jira v2 API was deprecated on May 1st - build is broken

### DIFF
--- a/layouts/shortcodes/jiraGetNewbieIssues.html
+++ b/layouts/shortcodes/jiraGetNewbieIssues.html
@@ -1,4 +1,4 @@
-{{- $issuesData := resources.GetRemote "https://perconadev.atlassian.net/rest/api/2/search?jql=status%20in%20(Open%2C%20New)%20AND%20labels%20%3D%20newbie" (dict "timeout" "5s") | transform.Unmarshal -}}
+{{- $issuesData := resources.GetRemote "https://perconadev.atlassian.net/rest/api/3/search/jql?jql=status%20in%20(Open%2C%20New)%20AND%20labels%20%3D%20newbie" (dict "timeout" "5s") | transform.Unmarshal -}}
 
 ### Task list
 


### PR DESCRIPTION
Make the blog build again

Deprecation of JQL search and Evaluate expression endpoints

[Jira documentation](https://developer.atlassian.com/changelog/#CHANGE-2046)