### PR TITLE
remove file name and typo fix

### DIFF
--- a/content/blog/2026/2026-05-19-pgb-the-way-is-open.md
+++ b/content/blog/2026/2026-05-19-pgb-the-way-is-open.md
@@ -98,7 +98,7 @@ This is what open source actually requires: not heroics, but coordination.
 It's all good. Well, better.
 
 
-![blog/2026/05/jan-pgb-back-cover.png](blog/2026/05/Jan-pgb-back-cover.png) Jan-pgb-back-cover.png
+![blog/2026/05/Jan-pgb-back-cover.png](blog/2026/05/Jan-pgb-back-cover.png)
 
 
 The short version:


### PR DESCRIPTION
there was a file name after an image that needed removing and there was a typo in the file name 