### PR TITLE
docs: fix PostgreSQL spelling in FOSDEM event tags

### DIFF
--- a/content/events/2026-fosdem/index.md
+++ b/content/events/2026-fosdem/index.md
@@ -7,7 +7,7 @@ layout: single
 speakers:
 - pep_pla
 date: '2026-01-30'
-tags: ["Event", "opensource", "sponsorship", "Cloud Native", "Kubernetes", "MariaDB", "PostgresSQL", "MySQL"]
+tags: ["Event", "opensource", "sponsorship", "Cloud Native", "Kubernetes", "MariaDB", "PostgreSQL", "MySQL"]
 events_year: ["2026"]
 events_category: ["Sponsorship"]
 events_tag: ["In-Person"]


### PR DESCRIPTION
Corrects `PostgresSQL` to `PostgreSQL` in `content/events/2026-fosdem/index.md`.

Verification:
- Found the typo via GitHub code search.
- Confirmed the current upstream base contains exactly one occurrence in the target file.
- Checked for existing open PRs mentioning `PostgresSQL` before opening this PR.
