### PR TITLE
Fix template error with recent hugo versions

### DIFF
--- a/layouts/tags/rss.xml
+++ b/layouts/tags/rss.xml
@@ -40,8 +40,10 @@
       <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>
       <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-      {{- with .Site.Author.email -}}
-      <author>{{ . }}{{ with $.Site.Author.name }} ({{ . }}){{ end }}</author>
+      {{- with site.Params.author -}}
+      {{- with .email -}}
+      <author>{{ . }}{{ with $.Site.Params.author.name }} ({{ . }}){{ end }}</author>
+      {{- end -}}
       {{- end -}}
       <guid isPermaLink="true">{{ .Permalink }}</guid>
       <description>{{ .Summary | html }}</description>


### PR DESCRIPTION
Obliviously also needs verification with older / currently used versions, but the template failed on the current version shipped by tumbleweed