### PR TITLE
Fix deprecated Hugo template functions

### DIFF
--- a/layouts/shortcodes/articleListByData.html
+++ b/layouts/shortcodes/articleListByData.html
@@ -1,4 +1,4 @@
-{{ $data := .Site.Data.articles }}
+{{ $data := hugo.Data.articles }}
 
 <div class="jspag" id="al-pag">
   <div class="jspag__toolbar">

--- a/layouts/shortcodes/youtubeListByData.html
+++ b/layouts/shortcodes/youtubeListByData.html
@@ -1,4 +1,4 @@
-{{ $data := .Site.Data.youtube }}
+{{ $data := hugo.Data.youtube }}
 
 <div class="jspag" id="yt-pag">
   <div class="jspag__toolbar">

--- a/layouts/tags/rss.xml
+++ b/layouts/tags/rss.xml
@@ -28,7 +28,7 @@
     <description>Recent content in {{ .Title }} on {{ .Site.Title }}</description>
     {{- end -}}
     <generator>Hugo {{ hugo.Version }}</generator>
-    <language>{{ site.Language.LanguageCode }}</language>
+    <language>{{ site.Language.Locale }}</language>
     {{- with $pages -}}
     <lastBuildDate>{{ (index $pages 0).Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>
     {{- end -}}


### PR DESCRIPTION
Replace .Site.Data with hugo.Data and .Language.LanguageCode with .Language.Locale to remove deprecation warnings from recent Hugo versions.